### PR TITLE
Implement auto-reload of user events after navigation

### DIFF
--- a/lib/view/events/event_detail/cubit/event_detail_cubit.dart
+++ b/lib/view/events/event_detail/cubit/event_detail_cubit.dart
@@ -12,8 +12,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 class EventDetailCubit extends Cubit<EventDetailState> {
   final EventRepository eventRepository;
   final UserRepository userRepository;
-  final LocalizationService l10n; 
+  final LocalizationService l10n;
   Event _event;
+  bool _hasChanged = false;
 
   final _effectController = StreamController<EventDetailEffect>.broadcast();
   Stream<EventDetailEffect> get effects => _effectController.stream;
@@ -21,7 +22,7 @@ class EventDetailCubit extends Cubit<EventDetailState> {
   EventDetailCubit({
     required this.eventRepository,
     required this.userRepository,
-    required this.l10n, 
+    required this.l10n,
     required Event event,
   })  : _event = event,
         super(EventDetailState(
@@ -87,6 +88,8 @@ class EventDetailCubit extends Cubit<EventDetailState> {
       }
 
       _event = updated;
+      _hasChanged = true; 
+
       emit(state.copyWith(
         uiModel: EventDetailUiMapper.map(
           updated,
@@ -119,7 +122,7 @@ class EventDetailCubit extends Cubit<EventDetailState> {
     }
   }
 
-  void backPressed() => _emitEffect(NavigateBackEffect());
+  void backPressed() => _emitEffect(NavigateBackEffect(_hasChanged));
 
   void _emitEffect(EventDetailEffect effect) => _effectController.add(effect);
 
@@ -128,7 +131,8 @@ class EventDetailCubit extends Cubit<EventDetailState> {
     _effectController.close();
     return super.close();
   }
+
   void viewAttendeesPressed() {
-  _emitEffect(NavigateToAttendeesEffect(_event.id));
-}
+    _emitEffect(NavigateToAttendeesEffect(_event.id));
+  }
 }

--- a/lib/view/events/event_detail/cubit/event_detail_effect.dart
+++ b/lib/view/events/event_detail/cubit/event_detail_effect.dart
@@ -2,7 +2,10 @@
 
 abstract class EventDetailEffect {}
 
-class NavigateBackEffect extends EventDetailEffect {}
+class NavigateBackEffect extends EventDetailEffect {
+  final bool eventChanged;
+  NavigateBackEffect(this.eventChanged);
+}
 class NavigateToLoginEffect extends EventDetailEffect {}
 class ShowJoinSuccessEffect extends EventDetailEffect {}
 class ShowLeaveSuccessEffect extends EventDetailEffect {}

--- a/lib/view/events/event_detail/view/event_detail_screen.dart
+++ b/lib/view/events/event_detail/view/event_detail_screen.dart
@@ -57,17 +57,11 @@ class _EventDetailFormState extends State<_EventDetailForm> {
       if (!mounted) return;
       final l10n = getIt<LocalizationService>().current;
       if (effect is NavigateBackEffect) {
-        context.pop();
+        context.pop(effect.eventChanged);
       } else if (effect is NavigateToLoginEffect) {
         widget.goToLogin();
       } else if (effect is NavigateToAttendeesEffect) {
         widget.goToAttendees(effect.eventId);
-      }   
-      if (effect is NavigateBackEffect) {
-        context.pop();
-      } else if (effect is NavigateToLoginEffect) {
-        debugPrint("Navigate");
-        widget.goToLogin();
       } else if (effect is ShowJoinSuccessEffect) {
         _showSnack(l10n.snackbarEventJoined);
       } else if (effect is ShowLeaveSuccessEffect) {
@@ -78,7 +72,7 @@ class _EventDetailFormState extends State<_EventDetailForm> {
         _showSnack(l10n.defaultErrorTitle);
       } else if (effect is OpenMapsEffect) {
         _openMaps(effect.lat, effect.lng, effect.name);
-      }
+      } 
     });
   }
 

--- a/lib/view/events/my_events/cubit/my_events_cubit.dart
+++ b/lib/view/events/my_events/cubit/my_events_cubit.dart
@@ -33,7 +33,7 @@ class MyEventsCubit extends Cubit<MyEventsState> {
 
   MyEventsCubit({required this.eventRepository, required this.userRepository}) : super(const MyEventsState());
 
-  Future<void> load() async {
+  Future<void> load({bool forceRefresh = false}) async {
     emit(const MyEventsState(loading: true));
     try {
       await userRepository.getUser();
@@ -42,7 +42,7 @@ class MyEventsCubit extends Cubit<MyEventsState> {
       return;
     }
     try {
-      final events = await eventRepository.getEvents(forceRefresh: false);
+      final events = await eventRepository.getEvents(forceRefresh: forceRefresh); 
       _myEvents = events.where((e) => e.userJoined).toList();
       if (_myEvents.isEmpty) {
         emit(const MyEventsState(loading: false, error: MyEventsEffectType.emptyList));

--- a/lib/view/events/my_events/view/my_events_screen.dart
+++ b/lib/view/events/my_events/view/my_events_screen.dart
@@ -12,7 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lottie/lottie.dart';
 
 class MyEventsScreen extends StatelessWidget {
-  final void Function(Event) onDetailsClicked;
+  final Future<void> Function(Event) onDetailsClicked;
   final void Function() onSignInClicked;
 
   const MyEventsScreen({super.key, required this.onDetailsClicked, required this.onSignInClicked});
@@ -27,7 +27,7 @@ class MyEventsScreen extends StatelessWidget {
 }
 
 class _MyEventsForm extends StatefulWidget {
-  final void Function(Event) onDetailsClicked;
+  final Future<void> Function(Event) onDetailsClicked;
   final void Function() onSignInClicked;
 
   const _MyEventsForm(this.onDetailsClicked, this.onSignInClicked);
@@ -44,13 +44,14 @@ class _MyEventsFormState extends State<_MyEventsForm> {
     super.initState();
     _cubit = context.read<MyEventsCubit>();
     _cubit.load();
-    _cubit.effects.listen((effect) {
+    _cubit.effects.listen((effect) async {
       if (effect is MyEventsEffectShowNoNetworkPrompt) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.snackbarNoInternet)),
         );
       } else if (effect is MyEventsEffectNavigateToEventDetail) {
-        widget.onDetailsClicked(effect.event);
+        await widget.onDetailsClicked(effect.event);
+        _cubit.load(forceRefresh: true);
       } else if (effect is MyEventsEffectNavigateToSignIn) {
         widget.onSignInClicked();
       }

--- a/lib/view/events/my_events/view/my_events_screen.dart
+++ b/lib/view/events/my_events/view/my_events_screen.dart
@@ -12,7 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lottie/lottie.dart';
 
 class MyEventsScreen extends StatelessWidget {
-  final Future<void> Function(Event) onDetailsClicked;
+  final Future<bool?> Function(Event) onDetailsClicked;
   final void Function() onSignInClicked;
 
   const MyEventsScreen({super.key, required this.onDetailsClicked, required this.onSignInClicked});
@@ -27,7 +27,7 @@ class MyEventsScreen extends StatelessWidget {
 }
 
 class _MyEventsForm extends StatefulWidget {
-  final Future<void> Function(Event) onDetailsClicked;
+  final Future<bool?> Function(Event) onDetailsClicked; 
   final void Function() onSignInClicked;
 
   const _MyEventsForm(this.onDetailsClicked, this.onSignInClicked);
@@ -50,8 +50,10 @@ class _MyEventsFormState extends State<_MyEventsForm> {
           SnackBar(content: Text(AppLocalizations.of(context)!.snackbarNoInternet)),
         );
       } else if (effect is MyEventsEffectNavigateToEventDetail) {
-        await widget.onDetailsClicked(effect.event);
-        _cubit.load(forceRefresh: true);
+        final didChange = await widget.onDetailsClicked(effect.event); 
+        if (didChange == true) {
+          _cubit.load(forceRefresh: true);
+        }
       } else if (effect is MyEventsEffectNavigateToSignIn) {
         widget.onSignInClicked();
       }

--- a/lib/view/navigation/app_routes.dart
+++ b/lib/view/navigation/app_routes.dart
@@ -172,8 +172,8 @@ class AppRoutes {
               pageBuilder: (context, state) => CustomTransitionPage(
                 key: state.pageKey,
                 child: MyEventsScreen(
-                  onDetailsClicked: (event) {
-                    context.push(AppRoutes.eventDetail, extra: event);
+                  onDetailsClicked: (event) async {
+                    await context.push(AppRoutes.eventDetail, extra: event); 
                   },
                   onSignInClicked: () {
                     context.push(login);

--- a/lib/view/navigation/app_routes.dart
+++ b/lib/view/navigation/app_routes.dart
@@ -173,7 +173,8 @@ class AppRoutes {
                 key: state.pageKey,
                 child: MyEventsScreen(
                   onDetailsClicked: (event) async {
-                    await context.push(AppRoutes.eventDetail, extra: event); 
+                      final didChange = await context.push(AppRoutes.eventDetail, extra: event) as bool?;
+                      return didChange;
                   },
                   onSignInClicked: () {
                     context.push(login);


### PR DESCRIPTION
Adds await logic in MyEventsScreen and AppRoutes to force the Cubit to reload after the user returns from the EventDetailScreen