### PR TITLE
fix/MOB-498: Change vote button always enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -666,6 +666,10 @@ $RECYCLE.BIN/
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 /.flutter-plugins-dependencies
 /EsmorgaFlutter.code-workspace
+# generated plugins
+**/generatedPluginRegistrant.*
+**/generated_plugin_registrant.cc
+**/generated_plugins.cmake
 
 
 lib/view/l10n/app_localization*.dart

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # Test coverage files
 coverage/
 
+# Screenshot tests failutes
+test/screenshot/failures/
+
 # Visual Studio Code related
 .vscode/
 

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -241,5 +241,6 @@ Future<void> setupDi(Locale locale) async {
   getIt.registerFactoryParam<PollDetailCubit, Poll, void>((poll, _) => PollDetailCubit(
         poll: poll,
         votePollUseCase: getIt(),
+        l10n: getIt<LocalizationService>(),
       ));
 }

--- a/lib/view/poll_detail/cubit/poll_detail_cubit.dart
+++ b/lib/view/poll_detail/cubit/poll_detail_cubit.dart
@@ -1,18 +1,23 @@
 import 'package:esmorga_flutter/domain/poll/model/poll.dart';
 import 'package:esmorga_flutter/domain/poll/usecase/vote_poll_use_case.dart';
+import 'package:esmorga_flutter/view/l10n/localization_service.dart';
 import 'package:esmorga_flutter/view/poll_detail/cubit/poll_detail_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PollDetailCubit extends Cubit<PollDetailState> {
   final VotePollUseCase _votePollUseCase;
+  final LocalizationService l10n;
 
   PollDetailCubit({
     required Poll poll,
     required VotePollUseCase votePollUseCase,
+    required this.l10n,
   })  : _votePollUseCase = votePollUseCase,
         super(PollDetailState(
           poll: poll,
           currentSelection: List.from(poll.userSelectedOptionIds),
+          buttonText: _getButtonText(poll, l10n),
+          isButtonEnabled: _getButtonEnabled(poll, List.from(poll.userSelectedOptionIds), l10n),
         ));
 
   void toggleOption(String optionId) {
@@ -27,25 +32,31 @@ class PollDetailCubit extends Cubit<PollDetailState> {
       current.clear();
       current.add(optionId);
     }
-    emit(state.copyWith(currentSelection: current, showSuccessMessage: false));
+    emit(state.copyWith(
+        currentSelection: current,
+        buttonText: _getButtonText(state.poll, l10n),
+        isButtonEnabled: _getButtonEnabled(state.poll, current, l10n),
+        showSuccessMessage: false));
   }
 
   Future<void> vote() async {
     if (state.currentSelection.isEmpty) return;
 
-    emit(state.copyWithClearError(isLoading: true, showSuccessMessage: false));
+    emit(state.copyWithClearError(isButtonLoading: true, showSuccessMessage: false));
 
     try {
       final updatedPoll = await _votePollUseCase(state.poll.id, state.currentSelection);
       emit(state.copyWith(
         poll: updatedPoll,
         currentSelection: updatedPoll.userSelectedOptionIds,
-        isLoading: false,
+        buttonText: _getButtonText(updatedPoll, l10n),
+        isButtonEnabled: _getButtonEnabled(updatedPoll, updatedPoll.userSelectedOptionIds, l10n),
+        isButtonLoading: false,
         showSuccessMessage: true,
       ));
     } catch (e) {
       emit(state.copyWith(
-        isLoading: false,
+        isButtonLoading: false,
         error: e.toString(),
         showSuccessMessage: false,
       ));
@@ -54,5 +65,20 @@ class PollDetailCubit extends Cubit<PollDetailState> {
 
   void clearSuccessMessage() {
     emit(state.copyWith(showSuccessMessage: false));
+  }
+
+  static String _getButtonText(Poll poll, LocalizationService l10n) {
+    final isDeadlinePassed = DateTime.now().isAfter(poll.voteDeadline);
+    final hasVoted = poll.userSelectedOptionIds.isNotEmpty;
+    return isDeadlinePassed
+        ? l10n.current.buttonDeadlinePassed
+        : (hasVoted ? l10n.current.buttonPollChangeVote : l10n.current.buttonPollVote);
+  }
+
+  static bool _getButtonEnabled(Poll poll, List<String> currentSelection, LocalizationService l10n) {
+    final isDeadlinePassed = DateTime.now().isAfter(poll.voteDeadline);
+    final hasVoteChanged = (poll.userSelectedOptionIds.length != currentSelection.length) ||
+        poll.userSelectedOptionIds.indexWhere(currentSelection.contains) == -1;
+    return !isDeadlinePassed && currentSelection.isNotEmpty && hasVoteChanged;
   }
 }

--- a/lib/view/poll_detail/cubit/poll_detail_state.dart
+++ b/lib/view/poll_detail/cubit/poll_detail_state.dart
@@ -4,14 +4,18 @@ import 'package:esmorga_flutter/domain/poll/model/poll.dart';
 class PollDetailState extends Equatable {
   final Poll poll;
   final List<String> currentSelection;
-  final bool isLoading;
+  final bool isButtonLoading;
+  final String buttonText;
+  final bool isButtonEnabled;
   final String? error;
   final bool showSuccessMessage;
 
   const PollDetailState({
     required this.poll,
     this.currentSelection = const [],
-    this.isLoading = false,
+    this.isButtonLoading = false,
+    this.buttonText = '',
+    this.isButtonEnabled = false,
     this.error,
     this.showSuccessMessage = false,
   });
@@ -19,14 +23,18 @@ class PollDetailState extends Equatable {
   PollDetailState copyWith({
     Poll? poll,
     List<String>? currentSelection,
-    bool? isLoading,
+    bool? isButtonLoading,
+    String? buttonText,
+    bool? isButtonEnabled,
     String? error,
     bool? showSuccessMessage,
   }) {
     return PollDetailState(
       poll: poll ?? this.poll,
       currentSelection: currentSelection ?? this.currentSelection,
-      isLoading: isLoading ?? this.isLoading,
+      isButtonLoading: isButtonLoading ?? this.isButtonLoading,
+      buttonText: buttonText ?? this.buttonText,
+      isButtonEnabled: isButtonEnabled ?? this.isButtonEnabled,
       error: error,
       showSuccessMessage: showSuccessMessage ?? this.showSuccessMessage,
     );
@@ -36,18 +44,22 @@ class PollDetailState extends Equatable {
   PollDetailState copyWithClearError({
     Poll? poll,
     List<String>? currentSelection,
-    bool? isLoading,
+    bool? isButtonLoading,
+    String? buttonText,
+    bool? isButtonEnabled,
     bool? showSuccessMessage,
   }) {
     return PollDetailState(
       poll: poll ?? this.poll,
       currentSelection: currentSelection ?? this.currentSelection,
-      isLoading: isLoading ?? this.isLoading,
+      isButtonLoading: isButtonLoading ?? this.isButtonLoading,
+      buttonText: buttonText ?? this.buttonText,
+      isButtonEnabled: isButtonEnabled ?? this.isButtonEnabled,
       error: null,
       showSuccessMessage: showSuccessMessage ?? this.showSuccessMessage,
     );
   }
 
   @override
-  List<Object?> get props => [poll, currentSelection, isLoading, error, showSuccessMessage];
+  List<Object?> get props => [poll, currentSelection, isButtonLoading, error, showSuccessMessage];
 }

--- a/lib/view/poll_detail/view/poll_detail_screen.dart
+++ b/lib/view/poll_detail/view/poll_detail_screen.dart
@@ -185,11 +185,9 @@ class _PollDetailView extends StatelessWidget {
                           ),
                         const SizedBox(height: 24),
                         EsmorgaButton(
-                          text: isDeadlinePassed
-                              ? l10n.buttonDeadlinePassed
-                              : (hasVoted ? l10n.buttonPollChangeVote : l10n.buttonPollVote),
-                          isEnabled: !isDeadlinePassed && state.currentSelection.isNotEmpty,
-                          isLoading: state.isLoading,
+                          text: state.buttonText,
+                          isEnabled: state.isButtonEnabled,
+                          isLoading: state.isButtonLoading,
                           onClick: () => cubit.vote(),
                         ),
                       ],

--- a/test/screenshot/poll_detail_screenshot_test.dart
+++ b/test/screenshot/poll_detail_screenshot_test.dart
@@ -74,6 +74,7 @@ void main() {
       when(() => cubit.state).thenReturn(PollDetailState(
         poll: poll,
         currentSelection: const [],
+        buttonText: 'Vote',
       ));
       return buildScreen();
     },
@@ -102,6 +103,8 @@ void main() {
       when(() => cubit.state).thenReturn(PollDetailState(
         poll: multiPoll,
         currentSelection: const ['1'],
+        buttonText: 'Change my vote',
+        isButtonEnabled: true,
       ));
       return PollDetailScreen(poll: multiPoll);
     },
@@ -125,6 +128,7 @@ void main() {
       when(() => cubit.state).thenReturn(PollDetailState(
         poll: passedPoll,
         currentSelection: const [],
+        buttonText: 'Too late',
       ));
       return PollDetailScreen(poll: passedPoll);
     },

--- a/test/view/poll_detail/poll_detail_cubit_test.dart
+++ b/test/view/poll_detail/poll_detail_cubit_test.dart
@@ -3,54 +3,54 @@ import 'package:esmorga_flutter/domain/poll/model/poll.dart';
 import 'package:esmorga_flutter/domain/poll/usecase/vote_poll_use_case.dart';
 import 'package:esmorga_flutter/view/poll_detail/cubit/poll_detail_cubit.dart';
 import 'package:esmorga_flutter/view/poll_detail/cubit/poll_detail_state.dart';
+import 'package:esmorga_flutter/view/l10n/app_localizations_en.dart';
+import 'package:esmorga_flutter/view/l10n/localization_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockVotePollUseCase extends Mock implements VotePollUseCase {}
 
+class _MockLocalizationService extends Mock implements LocalizationService {}
+
 void main() {
   late MockVotePollUseCase votePollUseCase;
+  late _MockLocalizationService l10n;
 
   setUp(() {
     votePollUseCase = MockVotePollUseCase();
+    l10n = _MockLocalizationService();
+    when(() => l10n.current).thenReturn(AppLocalizationsEn());
   });
 
-  final poll = Poll(
-    id: '1',
-    name: 'Poll 1',
-    description: 'desc',
-    options: const [
-      PollOption(id: 'opt1', option: 'Option 1', voteCount: 0),
-      PollOption(id: 'opt2', option: 'Option 2', voteCount: 0),
-    ],
-    userSelectedOptionIds: const [],
-    voteDeadline: DateTime.now().add(const Duration(days: 1)),
-    isMultipleChoice: false,
-  );
+  Poll getPoll({bool? multi, List<String>? selectedOptions}) {
+    return Poll(
+      id: '1',
+      name: 'Poll 1',
+      description: 'desc',
+      options: const [
+        PollOption(id: 'opt1', option: 'Option 1', voteCount: 5),
+        PollOption(id: 'opt2', option: 'Option 2', voteCount: 3),
+      ],
+      userSelectedOptionIds: selectedOptions ?? const [],
+      voteDeadline: DateTime.now().add(const Duration(days: 1)),
+      isMultipleChoice: multi ?? false,
+    );
+  }
 
-  final multiPoll = Poll(
-    id: '2',
-    name: 'Poll 2',
-    description: 'desc',
-    options: const [
-      PollOption(id: 'opt1', option: 'Option 1', voteCount: 0),
-      PollOption(id: 'opt2', option: 'Option 2', voteCount: 0),
-    ],
-    userSelectedOptionIds: const [],
-    voteDeadline: DateTime.now().add(const Duration(days: 1)),
-    isMultipleChoice: true,
-  );
+  final poll = getPoll();
+
+  final multiPoll = getPoll(multi: true);
 
   group('PollDetailCubit', () {
     test('initial state is correct', () {
-      final cubit = PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase);
+      final cubit = PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase, l10n: l10n);
       expect(cubit.state.poll, poll);
       expect(cubit.state.currentSelection, isEmpty);
     });
 
     blocTest<PollDetailCubit, PollDetailState>(
       'toggleOption selects option in single choice',
-      build: () => PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase),
+      build: () => PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase, l10n: l10n),
       act: (cubit) => cubit.toggleOption('opt1'),
       expect: () => [
         isA<PollDetailState>().having((s) => s.currentSelection, 'selection', ['opt1']),
@@ -59,7 +59,7 @@ void main() {
 
     blocTest<PollDetailCubit, PollDetailState>(
       'toggleOption switches option in single choice',
-      build: () => PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase),
+      build: () => PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase, l10n: l10n),
       act: (cubit) {
         cubit.toggleOption('opt1');
         cubit.toggleOption('opt2');
@@ -72,7 +72,7 @@ void main() {
 
     blocTest<PollDetailCubit, PollDetailState>(
       'toggleOption adds/removes option in multiple choice',
-      build: () => PollDetailCubit(poll: multiPoll, votePollUseCase: votePollUseCase),
+      build: () => PollDetailCubit(poll: multiPoll, votePollUseCase: votePollUseCase, l10n: l10n),
       act: (cubit) {
         cubit.toggleOption('opt1');
         cubit.toggleOption('opt2');
@@ -86,10 +86,13 @@ void main() {
     );
 
     blocTest<PollDetailCubit, PollDetailState>(
-      'vote emits loading then success',
+      'given successful useCase when user votes then cubit emits success state with button disabled',
       build: () {
-        when(() => votePollUseCase(any(), any())).thenAnswer((_) async => poll);
-        return PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase);
+        when(() => votePollUseCase(any(), any())).thenAnswer((_) async => getPoll(
+              multi: true,
+              selectedOptions: const ['opt1'],
+            ));
+        return PollDetailCubit(poll: multiPoll, votePollUseCase: votePollUseCase, l10n: l10n);
       },
       act: (cubit) {
         cubit.toggleOption('opt1');
@@ -97,10 +100,12 @@ void main() {
       },
       expect: () => [
         isA<PollDetailState>().having((s) => s.currentSelection, 'selection', ['opt1']),
-        isA<PollDetailState>().having((s) => s.isLoading, 'loading', true),
+        isA<PollDetailState>().having((s) => s.isButtonLoading, 'loading', true),
         isA<PollDetailState>()
-            .having((s) => s.isLoading, 'loading', false)
-            .having((s) => s.showSuccessMessage, 'success', true),
+            .having((s) => s.isButtonLoading, 'loading', false)
+            .having((s) => s.showSuccessMessage, 'success', true)
+            .having((s) => s.isButtonEnabled, 'button enabled', false)
+            .having((s) => s.buttonText, 'button text', l10n.current.buttonPollChangeVote)
       ],
     );
 
@@ -108,7 +113,7 @@ void main() {
       'vote emits loading then error',
       build: () {
         when(() => votePollUseCase(any(), any())).thenThrow(Exception('error'));
-        return PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase);
+        return PollDetailCubit(poll: poll, votePollUseCase: votePollUseCase, l10n: l10n);
       },
       act: (cubit) {
         cubit.toggleOption('opt1');
@@ -116,8 +121,10 @@ void main() {
       },
       expect: () => [
         isA<PollDetailState>().having((s) => s.currentSelection, 'selection', ['opt1']),
-        isA<PollDetailState>().having((s) => s.isLoading, 'loading', true),
-        isA<PollDetailState>().having((s) => s.isLoading, 'loading', false).having((s) => s.error, 'error', isNotNull),
+        isA<PollDetailState>().having((s) => s.isButtonLoading, 'loading', true),
+        isA<PollDetailState>()
+            .having((s) => s.isButtonLoading, 'loading', false)
+            .having((s) => s.error, 'error', isNotNull),
       ],
     );
   });

--- a/test/view/poll_detail/view/poll_detail_screen_test.dart
+++ b/test/view/poll_detail/view/poll_detail_screen_test.dart
@@ -70,7 +70,11 @@ void main() {
   }
 
   testWidgets('renders poll details correctly', (tester) async {
-    when(() => cubit.state).thenReturn(PollDetailState(poll: poll));
+    when(() => cubit.state).thenReturn(PollDetailState(
+      poll: poll,
+      buttonText: 'Vote',
+      isButtonEnabled: true,
+    ));
 
     await tester.pumpWidget(createWidgetUnderTest());
 
@@ -96,6 +100,8 @@ void main() {
     when(() => cubit.state).thenReturn(PollDetailState(
       poll: poll,
       currentSelection: ['opt1'],
+      buttonText: 'Vote',
+      isButtonEnabled: true,
     ));
     when(() => cubit.vote()).thenAnswer((_) async {});
 
@@ -103,7 +109,7 @@ void main() {
 
     final buttonFinder = find.widgetWithText(ElevatedButton, 'Vote');
     expect(buttonFinder, findsOneWidget);
-    
+
     await tester.tap(buttonFinder);
     verify(() => cubit.vote()).called(1);
   });


### PR DESCRIPTION
Added 2 new properties in poll_detail_state, buttonText and isButtonEnabled. State of the button can now be controlled at cubit level, removing business logic from the view layer. 